### PR TITLE
Load configurations from input files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,13 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MonteCarlo = "07692032-97b4-4f8d-80d7-e18df88d31a9"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 DelimitedFiles = "1.9.1"
 MonteCarlo = "0.1.0"
+Statistics = "1.11.1"
 Test = "1.11.0"
+YAML = "0.4.12"

--- a/scripts/main.jl
+++ b/scripts/main.jl
@@ -1,0 +1,29 @@
+using MonteCarlo
+using ParticlesMC
+
+include("parse_input.jl")
+
+function main(args)
+
+    verbose = args["verbose"]
+    # Print arguments
+    if verbose
+        println("Parsed args:")
+        for (arg, val) in args
+            println("  $arg  =>  $val")
+        end
+    end
+
+    # Load init file (or files)
+    init_path = args["init_file"]
+    chains = load_init_files(init_path; args=args, verbose=verbose, tails=".xyz")
+
+    return nothing
+    
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    cl_args = parse_commandline()
+    args = load_config_file(cl_args)
+    main(args)
+end

--- a/scripts/parse_input.jl
+++ b/scripts/parse_input.jl
@@ -1,0 +1,55 @@
+using ArgParse
+using YAML
+
+function parse_commandline()
+    parser = ArgParseSettings()
+    @add_arg_table! parser begin
+        "init_file"
+        help = "Path to the initial configuration file (accepts multiple files)"
+        arg_type = String
+        required = true
+        "config_file"
+        help = "Path to the simulation parameters file (e.g., input.yaml)"
+        arg_type = String
+        required = true
+        "--steps"
+        help = "Ovveride the number of steps in the config file"
+        arg_type = Int
+        "--nsim"
+        help = "Ovveride the number of chains per config file"
+        arg_type = Int
+        "--temperature", "-T"
+        help = "Ovveride the temperature in the input file"
+        arg_type = Float64
+        "--density", "-D"
+        help = "Ovveride the density in the input file (affine transformation)"
+        arg_type = Float64
+        "--model"
+        help = "Ovveride the model in the input file"
+        arg_type = String
+        "--list_type"
+        help = "Ovveride the cell list type (EmptyList or LinkedList)"
+        arg_type = String
+        "--verbose", "-v"
+        help = "verbose"
+        action = :store_true
+        "--seed"
+        help = "Override random number seed"
+        arg_type = Int
+    end
+
+    return parse_args(parser)
+
+end
+
+function load_config_file(cl_args)
+    args = YAML.load_file(cl_args["config_file"])
+    for key in keys(cl_args)
+        if cl_args[key] !== nothing
+            args[key] = cl_args[key]
+        end
+    end
+    return args
+end
+
+nothing

--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -12,7 +12,7 @@ include("models.jl")
 include("molecules.jl")
 include("atoms.jl")
 include("moves.jl")
-include("main.jl")
+
 
 export callback_energy
 export nearest_image_distance
@@ -25,4 +25,6 @@ export fold_back, System
 export SimpleGaussian, DoubleUniform, EnergyBias
 export sample_action!, log_proposal_density, reward, invert_action!, delta_log_target_density
 export perform_action!, perform_action_cached!
+export load_configuration, load_init_files
+
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 
-using ConcreteStructs
+using ConcreteStructs, Distributions
 
 function MonteCarlo.delta_log_target_density(e1, e2, system::Particles)
     return -(e2 - e1) ./ system.temperature
@@ -32,6 +32,55 @@ function SpeciesList(species)
         end
     end
     return SpeciesList(ids, heads)
+end
+
+function callback_energy(simulation)
+    return mean(mean(system.local_energy) for system in simulation.chains) / 2
+end
+
+function MonteCarlo.write_system(io, system::Particles)
+    println(io, "\tNumber of particles: $(system.N)")
+    println(io, "\tDimensions: $(system.d)")
+    println(io, "\tCell: $(system.box)")
+    println(io, "\tDensity: $(system.density)")
+    println(io, "\tTemperature: $(system.temperature)")
+    println(io, "\tCell list: " * replace(string(typeof(system.cell_list)), r"\{.*" => ""))
+    println(io, "\tModel: $(system.model.name)")
+    return nothing
+end
+
+function MonteCarlo.store_trajectory(trj, system::Particles, t)
+    println(trj, system.N)
+    box = replace(replace(string(system.box), r"[\[\]]" => ""), r",\s+" => ",")
+    println(trj, "step:$t columns:species,position dt:1 cell:$(box) rho:$(system.density) T:$(system.temperature) model:$(system.model.name) potential_energy_per_particle:$(mean(system.local_energy)/2)")
+    for (i, p) in enumerate(system.position)
+        print(trj, "$(system.species[i])")
+        for a in 1:system.d
+            print(trj, " $(p[a])")
+        end
+        println(trj)
+    end
+    return nothing
+end
+
+function load_configuration(path; m=-1)
+    data = readlines(path)
+    N = parse(Int, data[1])
+    metadata = split(data[2], " ")
+    cell_string = replace(metadata[findfirst(startswith("cell:"), metadata)], "cell:" => "")
+    cell_vector = parse.(Float64, split(cell_string, ","))
+    d = length(cell_vector)
+    box = SVector{d}(cell_vector)
+    selrow = m ≥ 0 ? (N + 2) * m - N + 1 : length(data) + m * (N + 2) + 3
+    frame = data[selrow:selrow+N-1]
+    sT = typeof(eval(Meta.parse(join(split(frame[1], " ")[1:end-d], " "))))
+    species = Vector{sT}(undef, N)
+    position = Vector{SVector{d}{Float64}}(undef, N)
+    for i in eachindex(frame)
+        species[i] = eval(Meta.parse(join(split(frame[i], " ")[1:end-d], " ")))
+        position[i] = SVector{d}(parse.(Float64, split(frame[i], " ")[end-d+1:end]))
+    end
+    return species, position, box, metadata
 end
 
 nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 
-using ConcreteStructs, Distributions
+using ConcreteStructs, Distributions, Statistics
 
 function MonteCarlo.delta_log_target_density(e1, e2, system::Particles)
     return -(e2 - e1) ./ system.temperature
@@ -81,6 +81,83 @@ function load_configuration(path; m=-1)
         position[i] = SVector{d}(parse.(Float64, split(frame[i], " ")[end-d+1:end]))
     end
     return species, position, box, metadata
+end
+
+function volume_sphere(r, d::Int)
+    d == 0 && return 1
+    d == 1 && return 2r
+    return 2π * r^2 * volume_sphere(r, d - 2) / d 
+end
+
+function load_init_files(init_path; args=Dict(), tails=".xyz", verbose=false)
+    input_files = Vector{String}()
+    if endswith(basename(init_path), tails)
+        push!(input_files, init_path)
+    elseif isdir(init_path)
+        for (root, dirs, files) in walkdir(init_path)
+            for file in files
+                if endswith(file, tails)
+                    push!(input_files, joinpath(root, file))
+                end
+            end
+        end
+    else
+        @error "Unknown format"
+    end
+    verbose && println("Processing $(length(input_files)) configuration file(s)")
+    verbose && @show input_files
+    input_data = load_configuration.(input_files)
+    initial_species_array = getindex.(input_data, 1)
+    initial_position_array = getindex.(input_data, 2)
+    initial_box_array = getindex.(input_data, 3)
+    metadata_array = getindex.(input_data, 4)
+    N = first(length.(initial_position_array))
+    d = first(length.(first(initial_position_array)))
+    @assert all(isequal(N), length.(initial_position_array))
+    @assert all(isequal(d), vcat([length.(X) for X in initial_position_array]...))
+    initial_density_array = length.(initial_position_array) ./ prod.(initial_box_array)
+    initial_temperature_array = [parse(Float64, split(filter(x -> occursin("T:", x), metadata)[1], ":")[2]) for metadata in metadata_array]
+    input_models = [split(filter(x -> occursin("model:", x), metadata)[1], ":")[2] for metadata in metadata_array]
+    @assert all(isequal(input_models[1]), input_models)
+    # Update density, temperature and model if needed
+    if haskey(args, "density") && !isnothing(args["density"])
+        λs = (initial_density_array ./ args["density"]) .^ (1 / d)
+        initial_density_array .= args["density"]
+        initial_position_array .= [X .* λ for (X, λ) in zip(initial_position_array, λs)]
+        initial_box_array .= [box .* λ for (box, λ) in zip(initial_box_array, λs)]
+    end
+    if haskey(args, "temperature") && !isnothing(args["temperature"])
+        initial_temperature_array .= args["temperature"]
+    end
+    if haskey(args, "model") && !isnothing(args["model"])
+        input_models .= args["model"]
+    end
+    # Fold back into the box
+    initial_position_array .= [[fold_back(x, box) for x in X] for (X, box) in zip(initial_position_array, initial_box_array)]
+    # Parse model
+    model = eval(Meta.parse(input_models[1] * "()"))
+    @assert isa(model, Model)
+    # Copy configurations nsim times (replicas)
+    if haskey(args, "nsim") && !isnothing(args["nsim"]) && args["nsim"] > 1
+        nsim = args["nsim"]
+        verbose && println("Generating $nsim replicas per input file")
+        initial_position_array = vcat([[copy(x) for _ in 1:nsim] for x in initial_position_array]...)
+        initial_species_array = vcat([[copy(x) for _ in 1:nsim] for x in initial_species_array]...)
+        initial_density_array = vcat([[copy(x) for _ in 1:nsim] for x in initial_density_array]...)
+        initial_temperature_array = vcat([[copy(x) for _ in 1:nsim] for x in initial_temperature_array]...)
+    end
+    # Handle cell list (this is classy)
+    available_species = unique(vcat(initial_species_array...))
+    maxcut = maximum([cutoff(spi, spj, model) for spi in available_species for spj in available_species])
+    Z = mean(initial_density_array) * volume_sphere(maxcut, d)
+    list_type = Z / N < 0.1 ? LinkedList : EmptyList
+    if haskey(args, "list_type") && !isnothing(args["list_type"])
+        list_type = eval(Meta.parse(args["list_type"]))
+    end
+    # Create independent chains
+    chains = [System(initial_position_array[k], initial_species_array[k], initial_density_array[k], initial_temperature_array[k], model, list_type=list_type) for k in eachindex(initial_position_array)]
+    verbose && println("$(length(chains)) chains created")
+    return chains
 end
 
 nothing

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -1,0 +1,16 @@
+# General simulation parameters
+steps: 10000             # Number of Monte Carlo sweep
+nsim: 1                  # Number of chains per input file
+temperature: null        # Overrides temperature of the system
+density: null            # Override density of the system
+model: JBB               # Override model
+seed: 1                  # Random number seeds
+
+
+# Initial conditions
+initial_positions:
+  - [1.0, 2.0, 3.0]     # Position of particle 1
+  - [2.0, 3.0, 4.0]     # Position of particle 2
+  - [3.0, 4.0, 5.0]     # Position of particle 3
+  - [4.0, 5.0, 6.0]     # Position of particle 4
+  # Add more particles as needed


### PR DESCRIPTION
I added a function called `load_init_files` that can load multiple xyz files and returns a vector of chains. This will be useful for the command line interface (which I already started in `scripts`, but it's better if we wait until we update `MonteCarlo` for the last part)