### PR TITLE
Clean up the code

### DIFF
--- a/src/IO/IO.jl
+++ b/src/IO/IO.jl
@@ -20,7 +20,7 @@ function Arianna.write_system(io, system::Particles)
     println(io, "\tCell: $(system.box)")
     println(io, "\tDensity: $(system.density)")
     println(io, "\tTemperature: $(system.temperature)")
-    println(io, "\tCell list: " * replace(string(typeof(system.cell_list)), r"\{.*" => ""))
+    println(io, "\tNeighbour list: " * replace(string(typeof(system.neighbour_list)), r"\{.*" => ""))
     return nothing
 end
 

--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -7,7 +7,7 @@ abstract type Particles <: AriannaSystem end
 
 
 include("utils.jl")
-include("cell_list.jl")
+include("neighbours.jl")
 include("models.jl")
 include("molecules.jl")
 include("atoms.jl")
@@ -18,7 +18,7 @@ get_species(system::Particles, i::Int) = @inbounds system.species[i]
 get_model(system::Particles, i::Int, j::Int) = @inbounds system.model_matrix[get_species(system, i), get_species(system, j)]
 get_local_energy(system::Particles, i::Int) = @inbounds system.local_energy[i]
 get_box(system::Particles) = system.box
-get_neighbour_list(system::Particles) = system.cell_list
+get_neighbour_list(system::Particles) = system.neighbour_list
 Base.length(system::Particles) = system.N
 Base.eachindex(system::Particles) = Base.OneTo(length(system))
 Base.getindex(system::Atoms, i::Int) = system.position[i], system.species[i], system.local_energy[i]
@@ -28,16 +28,8 @@ function Base.iterate(system::Union{Atoms, Molecules}, state=1)
     return (system.position[state], state + 1)  # Return element & next state
 end
 
-function compute_local_energy(system::Particles, i)
-    return compute_local_energy(system, i, system.cell_list)
-end
-
-function destroy_particle!(system::Particles, i)
-    return destroy_particle!(system, i, system.cell_list)
-end
-
-function create_particle!(system::Particles, i)
-    return destroy_particle!(system, i, system.cell_list)
+function compute_energy_particle(system::Particles, i)
+    return compute_energy_particle(system, i, system.neighbour_list)
 end
 
 

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -9,7 +9,7 @@ struct Atoms{D, Q, V<:AbstractVector, C<:NeighbourList, H, T<:AbstractFloat, SM<
     d::Int
     box::SVector{D,T}
     local_energy::MVector{Q, T}
-    cell_list::C
+    neighbour_list::C
     species_list::H
 end
 
@@ -23,11 +23,11 @@ function System(position, species, density::T, temperature::T, model_matrix; lis
     local_energy = MVector{N, T}(zeros(T, N))
     indices = MVector{N, Bool}(falses(N))
     maxcut = maximum([model.rcut for model in model_matrix])
-    cell_list = list_type(box, maxcut, N)
+    neighbour_list = list_type(box, maxcut, N)
     species_list = isa(species[1], Integer) ? SpeciesList(species) : nothing
-    system = Atoms(position, species, density, energy, temperature, model_matrix, N, d, box, local_energy, cell_list, species_list)
-    build_cell_list!(system)
-    system.local_energy .= [compute_local_energy(system, i) for i in eachindex(system)]
+    system = Atoms(position, species, density, energy, temperature, model_matrix, N, d, box, local_energy, neighbour_list, species_list)
+    build_neighbour_list!(system)
+    system.local_energy .= [compute_energy_particle(system, i) for i in eachindex(system)]
     system.energy[1] = sum(system.local_energy) / 2
     return system
 end
@@ -47,11 +47,11 @@ function compute_energy_ij(system::Atoms, position_i, position_j, model_ij::Mode
     return potential(r2, model_ij)
 end
 
-function compute_local_energy(system::Atoms, i)
-    return compute_local_energy(system, i, system.cell_list)
+function compute_energy_particle(system::Atoms, i)
+    return compute_energy_particle(system, i, system.neighbour_list)
 end
 
-function compute_local_energy(system::Atoms, i, ::EmptyList)
+function compute_energy_particle(system::Atoms, i, ::EmptyList)
     energy_i = zero(typeof(system.density))
     position_i = get_position(system, i)
     for (j, _) in enumerate(system)
@@ -61,140 +61,37 @@ function compute_local_energy(system::Atoms, i, ::EmptyList)
 end
 
 
-function destroy_particle!(system::Atoms, i, ::EmptyList)
+function compute_energy_particle(system::Atoms, i, neighbour_list::CellList)
     energy_i = zero(typeof(system.density))
     position_i = get_position(system, i)
-    # Loop over particles
-    @inbounds for (j, _) in enumerate(system)
-        energy_ij = check_compute_energy_ij(system, i, j, position_i)
-        energy_i += energy_ij
-    end
-    return energy_i
-end
+    c = get_cell_index(position_i, neighbour_list)
+    neighbour_cells = neighbour_list.neighbour_cells[c]
 
-function create_particle!(system::Atoms, i, ::EmptyList)
-    energy_i = zero(typeof(system.density))
-    position_i = get_position(system, i)
-    # Loop over particles
-    @inbounds for (j, position_j) in enumerate(system)
-        energy_ij = check_compute_energy_ij(system, i, j, position_i)
-        energy_i += energy_ij
-    end
-    return energy_i
-end
-
-function compute_local_energy(system::Atoms, i, cell_list::CellList)
-    energy_i = zero(typeof(system.density))
-    position_i = get_position(system, i)
-    mc = get_cell(position_i, cell_list)
     # Scan the neighbourhood of cell mc (including itself)
-    @inbounds for mc2 in Iterators.product(map(x -> x-1:x+1, mc)...)
-        # Calculate the scalar cell index of the neighbour cell (with PBC)
-        c2 = cell_index(cell_list, mc2)
+    @inbounds for c2 in neighbour_cells
         # Scan atoms in cell c2
-        @inbounds for j in cell_list.cells[c2]
+        neighbours = neighbour_list.cells[c2]
+        @inbounds for j in neighbours
             energy_i += check_compute_energy_ij(system, i, j, position_i)
         end
     end
     return energy_i
 end
 
-# With linked list
-function destroy_particle!(system::Atoms, i, cell_list::CellList)
-    # Get cell of particle i
-    energy_i = zero(typeof(system.density))
-    position_i = get_position(system, i)
-    mc = get_cell(position_i, cell_list)
-    # Scan the neighbourhood of cell mc (including itself)
-    @inbounds for mc2 in Iterators.product(map(x -> x-1:x+1, mc)...)
-        # Calculate the scalar cell index of the neighbour cell (with PBC)
-        c2 = cell_index(cell_list, mc2)
-        # Scan atoms in cell c2
-        neighbours = cell_list.cells[c2]
-        @inbounds for j in neighbours
-            energy_ij = check_compute_energy_ij(system, i, j, position_i)
-            energy_i += energy_ij
-        end
-    end
-    return energy_i
-end
-
-function create_particle!(system::Atoms, i, cell_list::CellList)
+function compute_energy_particle(system::Atoms, i, neighbour_list::LinkedList)
     energy_i = zero(typeof(system.density))
     # Get cell of particle i
     position_i = get_position(system, i)
-    mc = get_cell(position_i, cell_list)
+    c = get_cell_index(position_i, neighbour_list)
+    neighbour_cells = neighbour_list.neighbour_cells[c]
     # Scan the neighbourhood of cell mc (including itself)
-    @inbounds for mc2 in Iterators.product(map(x -> x-1:x+1, mc)...)
-        # Calculate the scalar cell index of the neighbour cell (with PBC)
-        c2 = cell_index(cell_list, mc2)
+    @inbounds for c2 in neighbour_cells
         # Scan atoms in cell c2
-        neighbours = cell_list.cells[c2]
-        @inbounds for j in neighbours
-            energy_ij = check_compute_energy_ij(system, i, j, position_i)
-            energy_i += energy_ij
-        end
-    end
-    return energy_i
-end
-
-
-function compute_local_energy(system::Atoms, i, cell_list::LinkedList)
-    energy_i = zero(typeof(system.density))
-    # Get cell of particle i
-    position_i = get_position(system, i)
-    mc = get_cell(position_i, cell_list)
-    # Scan the neighbourhood of cell mc (including itself)
-    @inbounds for mc2 in Iterators.product(map(x -> x-1:x+1, mc)...)
-        # Calculate the scalar cell index of the neighbour cell (with PBC)
-        c2 = cell_index(cell_list, mc2)
-        # Scan atoms in cell c2
-        j = cell_list.head[c2]
+        j = neighbour_list.head[c2]
         while (j != -1)
             energy_ij = check_compute_energy_ij(system, i, j, position_i)
             energy_i += energy_ij
-            j = cell_list.list[j]
-        end
-    end
-    return energy_i
-end
-
-
-function destroy_particle!(system::Atoms, i, cell_list::LinkedList)
-    energy_i = zero(typeof(system.density))
-    # Get cell of particle i
-    position_i = get_position(system, i)
-    mc = get_cell(position_i, cell_list)
-    # Scan the neighbourhood of cell mc (including itself)
-    @inbounds for mc2 in Iterators.product(map(x -> x-1:x+1, mc)...)
-        # Calculate the scalar cell index of the neighbour cell (with PBC)
-        c2 = cell_index(cell_list, mc2)
-        # Scan atoms in cell c2
-        j = cell_list.head[c2]
-        while (j != -1)
-            energy_ij = check_compute_energy_ij(system, i, j, position_i)
-            energy_i += energy_ij
-            j = cell_list.list[j]
-        end
-    end
-    return energy_i
-end
-
-function create_particle!(system::Atoms, i, cell_list::LinkedList)
-    energy_i = zero(typeof(system.density))
-    # Get cell of particle i
-    position_i = get_position(system, i)
-    mc = get_cell(position_i, cell_list)
-    # Scan the neighbourhood of cell mc (including itself)
-    @inbounds for mc2 in Iterators.product(map(x -> x-1:x+1, mc)...)
-        # Calculate the scalar cell index of the neighbour cell (with PBC)
-        c2 = cell_index(cell_list, mc2)
-        # Scan atoms in cell c2
-        j = cell_list.head[c2]
-        while (j != -1)
-            energy_ij = check_compute_energy_ij(system, i, j, position_i)
-            energy_i += energy_ij
-            j = cell_list.list[j]
+            j = neighbour_list.list[j]
         end
     end
     return energy_i

--- a/src/moves.jl
+++ b/src/moves.jl
@@ -2,7 +2,7 @@ using ComponentArrays
 
 function Arianna.perform_action!(system::Particles, action::Action)
     e₁, e₂ = perform_action!(system, action)
-    if isinf(e₁) || isinf(e₂)
+    if isinf(e₂)
         action.δe = zero(typeof(system.energy[1]))
     else
         action.δe = e₂ - e₁

--- a/src/moves.jl
+++ b/src/moves.jl
@@ -35,13 +35,13 @@ end
 
 function perform_action!(system::Particles, action::Displacement)
     neighbour_list = get_neighbour_list(system)
-    e₁ = destroy_particle!(system, action.i, neighbour_list)
+    e₁ = compute_energy_particle(system, action.i, neighbour_list)
     update_position!(system, action)
     c, c2 = old_new_cell(system, action.i, neighbour_list)
     if c != c2
-        update_cell_list!(action.i, c, c2, neighbour_list)
+        update_neighbour_list!(action.i, c, c2, neighbour_list)
     end
-    e₂ = create_particle!(system, action.i, neighbour_list)
+    e₂ = compute_energy_particle(system, action.i, neighbour_list)
     action.δe = e₂ - e₁
     return e₁, e₂
 end
@@ -52,7 +52,7 @@ function Arianna.revert_action!(system::Particles, action::Displacement)
     system.energy[1] -= action.δe
     c, c2 = old_new_cell(system, action.i, neighbour_list)
     if c != c2
-        update_cell_list!(action.i, c, c2, neighbour_list)
+        update_neighbour_list!(action.i, c, c2, neighbour_list)
     end
 end
 
@@ -87,12 +87,12 @@ mutable struct DiscreteSwap <: Action
 end
 
 function swap_particle_species!(system::Particles, spi, i, spj, j)
-    e₁ᵢ = destroy_particle!(system, i, system.cell_list)
-    e₁ⱼ = destroy_particle!(system, j, system.cell_list)
+    e₁ᵢ = compute_energy_particle(system, i, system.neighbour_list)
+    e₁ⱼ = compute_energy_particle(system, j, system.neighbour_list)
     system.species[i] = spj
     system.species[j] = spi
-    e₂ᵢ = create_particle!(system, i, system.cell_list)
-    e₂ⱼ = create_particle!(system, j, system.cell_list)
+    e₂ᵢ = compute_energy_particle(system, i, system.neighbour_list)
+    e₂ⱼ = compute_energy_particle(system, j, system.neighbour_list)
     return e₁ᵢ + e₁ⱼ, e₂ᵢ + e₂ⱼ
 end
 

--- a/src/moves.jl
+++ b/src/moves.jl
@@ -1,5 +1,16 @@
 using ComponentArrays
 
+function Arianna.perform_action!(system::Particles, action::Action)
+    e₁, e₂ = perform_action!(system, action)
+    if isinf(e₁) || isinf(e₂)
+        action.δe = zero(typeof(system.energy[1]))
+    else
+        action.δe = e₂ - e₁
+        system.energy[1] += action.δe
+    end
+    return e₁, e₂
+end
+
 ###############################################################################
 # SIMPLE DISPLACEMENT
 
@@ -22,7 +33,7 @@ function update_position!(system::Particles, action::Displacement)
     @inbounds system.position[action.i] = system.position[action.i] + action.δ
 end
 
-function Arianna.perform_action!(system::Particles, action::Displacement)
+function perform_action!(system::Particles, action::Displacement)
     neighbour_list = get_neighbour_list(system)
     e₁ = destroy_particle!(system, action.i, neighbour_list)
     update_position!(system, action)
@@ -32,7 +43,6 @@ function Arianna.perform_action!(system::Particles, action::Displacement)
     end
     e₂ = create_particle!(system, action.i, neighbour_list)
     action.δe = e₂ - e₁
-    system.energy[1] += action.δe
     return e₁, e₂
 end
 
@@ -92,12 +102,11 @@ function update_species_list!(species_list, swap_species, i, j)
     species_list.sp_heads[i], species_list.sp_heads[j] = species_list.sp_heads[j], species_list.sp_heads[i]
 end
 
-function Arianna.perform_action!(system::Particles, action::DiscreteSwap)
+function perform_action!(system::Particles, action::DiscreteSwap)
     i, j = action.i, action.j
     spi, spj = get_species(system, i), get_species(system, j)
     e₁, e₂ = swap_particle_species!(system, spi, i, spj, j)
     action.δe = e₂ - e₁
-    system.energy[1] += action.δe
     update_species_list!(system.species_list, action.species, i, j)
     return e₁, e₂
 end
@@ -157,12 +166,11 @@ mutable struct MoleculeFlip{F<:AbstractFloat} <: Action
     δe::F
 end
 
-function Arianna.perform_action!(system::Particles, action::MoleculeFlip)
+function perform_action!(system::Particles, action::MoleculeFlip)
     i, j = action.i, action.j
     spi, spj = system.species[i], system.species[j]
     e₁, e₂ = swap_particle_species!(system, spi, i, spj, j)
     action.δe = e₂ - e₁
-    system.energy[1] += action.δe
     return e₁, e₂
 end
 

--- a/src/neighbours.jl
+++ b/src/neighbours.jl
@@ -1,0 +1,205 @@
+using StaticArrays
+
+abstract type NeighbourList end
+
+function build_neighbour_list!(system::Particles)
+    return build_neighbour_list!(system, get_neighbour_list(system))
+end
+
+struct EmptyList <: NeighbourList end
+
+function EmptyList(box, rcut, N)
+    return EmptyList()
+end
+
+function build_neighbour_list!(::Particles,::EmptyList)
+    return nothing
+end
+
+function update_neighbour_list!(i, c, c2, ::EmptyList)
+    return nothing
+end
+
+function old_new_cell(::Particles, i, ::EmptyList)
+    return 1, 1
+end
+
+function get_cell_index(i::Int, neighbour_list::NeighbourList)
+    return neighbour_list.cs[i]
+end
+struct CellList{T<:AbstractFloat, d} <: NeighbourList
+    cs::Vector{Int}
+    box::SVector{d,T}
+    ncells::NTuple{d,Int}
+    cells::Vector{Vector{Int}}  # List of particles in each cell
+    neighbour_cells::Vector{Vector{Int}}  # List of neighbouring cells
+end
+
+function cell_index(neighbour_list::NeighbourList, mc::NTuple{d,Int}) where {d}
+    return cell_index(neighbour_list.ncells, mc)
+end
+
+function cell_index(ncells::NTuple{d, Int}, mc::NTuple{d,Int}) where {d}
+    mc_fold = fold_back(mc, ncells)
+    c = 1
+    stride = 1
+    for i in reverse(1:d)
+        c += mc_fold[i] * stride
+        stride *= ncells[i]
+    end
+    return c
+end
+
+function build_neighbour_cells(ncells::NTuple{d,Int}) where {d}
+    # Create a list of neighbour cells for each cell
+    neighbourcells = Vector{Vector{Int}}(undef, prod(ncells))
+    ranges = map(Base.OneTo, ncells)  # create ranges 1:n1, 1:n2, ...
+    for mc in Iterators.product(ranges...)
+        c = cell_index(ncells, mc)    
+        neighbours = []
+        for mc2 in Iterators.product(map(x -> x-1:x+1, mc)...)
+            # Calculate the scalar cell index of the neighbour cell (with PBC)
+            c2 = cell_index(ncells, mc2)
+            push!(neighbours, c2)
+        end
+        neighbourcells[c] = neighbours
+    end
+    return neighbourcells
+end
+
+function CellList(box::SVector{d,T}, rcut::T, N::Int) where {d,T<:AbstractFloat}
+    
+    # Calculate cell dimensions ensuring they're >= rcut
+    cell_box = @. box / floor(Int, box / rcut)
+    
+    # Calculate number of cells in each dimension
+    ncells = ntuple(i -> max(1, floor(Int, box[i] / cell_box[i])), d)
+    
+    # Initialize empty cells
+    cells = [Int[] for _ in 1:prod(ncells)]
+    
+    # Initialize cell indices for particles
+    cs = zeros(Int, N)
+    neighbour_cells = build_neighbour_cells(ncells)
+    return CellList(cs, cell_box, ncells, cells, neighbour_cells)
+end
+
+function build_neighbour_list!(system::Particles, neighbour_list::CellList)
+    # Reset cell list
+    #foreach(empty!, neighbour_list.cells)
+    #neighbour_list.cells = [Int[] for _ in 1:prod(neighbour_list.ncells)]
+    # Populate cell list
+    for (i, position_i) in enumerate(system)
+        c = get_cell_index(position_i, neighbour_list)
+        neighbour_list.cs[i] = c
+        push!(neighbour_list.cells[c], i)  # Directly append particle index
+    end
+    return nothing
+end
+
+function update_neighbour_list!(i, c, c2, neighbour_list::CellList)
+    # Remove from old cell using in-place filter
+    filter!(x -> x != i, neighbour_list.cells[c])
+    # Add to new cell
+    push!(neighbour_list.cells[c2], i)
+    # Update particle's cell index
+    neighbour_list.cs[i] = c2
+    return nothing
+end
+
+
+
+
+function get_cell(xi::SVector{d,T}, box::SVector{d,T}) where {d,T<:AbstractFloat}
+    return ntuple(a -> Int(fld(xi[a], box[a])), d)
+end
+
+function get_cell(xi::SVector{d,T}, neighbour_list::NeighbourList) where {d,T<:AbstractFloat}
+    return get_cell(xi, neighbour_list.box)
+end
+
+function get_cell_index(xi::SVector{d,T}, neighbour_list::NeighbourList) where {d,T<:AbstractFloat}
+    mc = get_cell(xi, neighbour_list)
+    return cell_index(neighbour_list, mc)
+end
+function old_new_cell(system::Particles, i, neighbour_list::CellList)
+    c = neighbour_list.cs[i]
+    # New cell index
+    mc2 = get_cell(get_position(system, i), neighbour_list)
+    c2 = cell_index(neighbour_list, mc2)
+    return c, c2
+end
+
+struct LinkedList{T<:AbstractFloat, d} <: NeighbourList
+    cs::Vector{Int}
+    box::SVector{d,T}
+    ncells::NTuple{d,Int}
+    head::Vector{Int}
+    list::Vector{Int}
+    rcut::T
+    neighbour_cells::Vector{Vector{Int}}
+end
+
+function LinkedList(box, rcut, N)
+    cell = box ./ fld.(box, rcut)
+    ncells = ntuple(a -> Int(box[a] / cell[a]), length(box))
+    head = -ones(Int, prod(ncells))
+    list = zeros(Int, N)
+    cs = zeros(Int, N)
+    neighbour_cells = build_neighbour_cells(ncells)
+    return LinkedList(cs, cell, ncells, head, list, rcut, neighbour_cells)
+end
+
+
+function build_neighbour_list!(system::Particles, neighbour_list::LinkedList)
+    # Reset the headers
+    for c in 1:prod(neighbour_list.ncells)
+        neighbour_list.head[c] = -1
+    end
+    # Scan system to construct headers and linked lists
+    for i in eachindex(system)
+        # Vector cell indices to which this atom belongs (0 ≤ mc[a] < nc[a] ∀a)
+        mc = get_cell(get_position(system, i), neighbour_list.box)
+        # Translate the vector cell indices, mc, to a scalar cell index
+        c = cell_index(neighbour_list, mc)
+        # Link to the previous occupant (or EMPTY (-1) if you're the 1st)
+        neighbour_list.list[i] = neighbour_list.head[c]
+        # The last one goes to the header
+        neighbour_list.head[c] = i
+        # Save cell indices
+        neighbour_list.cs[i] = c
+    end
+    return nothing
+end
+
+
+
+function update_neighbour_list!(i::Int, c::Int, c2::Int, neighbour_list::LinkedList)
+    # Remove particle from old cell (distinguish head or not)
+    if neighbour_list.head[c] == i
+        neighbour_list.head[c] = neighbour_list.list[i]
+    else
+        # Find preceding particle in old cell
+        j = neighbour_list.head[c]
+        while neighbour_list.list[j] != i
+            j = neighbour_list.list[j]
+        end
+        # Update list reference in old cell
+        neighbour_list.list[j] = neighbour_list.list[i]
+    end
+    # Insert particle into new cell (exchange with head)
+    neighbour_list.list[i] = neighbour_list.head[c2]
+    neighbour_list.head[c2] = i
+    # Update cell index
+    neighbour_list.cs[i] = c2
+    return nothing
+end
+
+function old_new_cell(system::Particles, i, neighbour_list::LinkedList)
+    c = neighbour_list.cs[i]
+    # New cell index
+    mc2 = get_cell(get_position(system, i), neighbour_list)
+    c2 = cell_index(neighbour_list, mc2)
+    return c, c2
+end
+

--- a/test/gerhard_energy_distribution.jl
+++ b/test/gerhard_energy_distribution.jl
@@ -36,7 +36,7 @@ pswap = 0.0
 displacement_policy = SimpleGaussian()
 displacement_parameters = ComponentArray(σ=0.05)
 pool = (
-    Move(Displacement(0, zero(system.box)), displacement_policy, displacement_parameters, 1 - pswap),
+    Move(Displacement(0, zero(system.box), 0.0), displacement_policy, displacement_parameters, 1 - pswap),
 )
 
 algorithm_list = (
@@ -66,9 +66,9 @@ displacement_parameters = ComponentArray(σ=0.05)
 swap_policy = DoubleUniform()
 swap_parameters = Vector{Float64}()
 pool = (
-    Move(Displacement(0, zero(system.box)), displacement_policy, displacement_parameters, 1 - pswap),
-    Move(DiscreteSwap(0, 0, (1, 3), (NA, NC)), swap_policy, swap_parameters, pswap / 2),
-    Move(DiscreteSwap(0, 0, (2, 3), (NB, NC)), swap_policy, swap_parameters, pswap / 2),
+    Move(Displacement(0, zero(system.box), 0.0), displacement_policy, displacement_parameters, 1 - pswap),
+    Move(DiscreteSwap(0, 0, (1, 3), (NA, NC), 0.0), swap_policy, swap_parameters, pswap / 2),
+    Move(DiscreteSwap(0, 0, (2, 3), (NB, NC), 0.0), swap_policy, swap_parameters, pswap / 2),
 )
 algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=system.N),
@@ -99,9 +99,9 @@ swap_BC_policy = EnergyBias()
 swap_AC_parameters = ComponentArray(θ₁=1.0, θ₂=0.5)
 swap_BC_parameters = ComponentArray(θ₁=0.5, θ₂=4.0)
 pool = (
-    Move(Displacement(0, zero(system.box)), displacement_policy, displacement_parameters, 1 - pswap),
-    Move(DiscreteSwap(0, 0, (1, 3), (NA, NC)), swap_AC_policy, swap_AC_parameters, pswap / 2),
-    Move(DiscreteSwap(0, 0, (2, 3), (NB, NC)), swap_BC_policy, swap_BC_parameters, pswap / 2),
+    Move(Displacement(0, zero(system.box), 0.0), displacement_policy, displacement_parameters, 1 - pswap),
+    Move(DiscreteSwap(0, 0, (1, 3), (NA, NC), 0.0), swap_AC_policy, swap_AC_parameters, pswap / 2),
+    Move(DiscreteSwap(0, 0, (2, 3), (NB, NC), 0.0), swap_BC_policy, swap_BC_parameters, pswap / 2),
 )
 algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=system.N),

--- a/test/molecules_test.jl
+++ b/test/molecules_test.jl
@@ -14,25 +14,6 @@ Length = 3
 d = 3
 temperature = 2.0
 density = 1.2
-box = @SVector fill(typeof(temperature)((N / density)^(1 / d)), d)
-position_1 = [box .* @SVector rand(rng, d) for i in 1:Int(N // Length), m in 1:M]
-position = []
-for r in position_1
-    push!(position, r)
-    push!(position, r .+ @SVector [0.1, 0.1, 0.1])
-    push!(position, r .- @SVector [0.1, 0.1, 0.1])
-end
-position = Vector{SVector{3,Float64}}(position)
-molecule = Vector{Int}()
-species = Vector{Int}()
-for i in 1:Int(N // Length)
-    push!(species, 1)
-    push!(species, 2)
-    push!(species, 3)
-    push!(molecule, i)
-    push!(molecule, i)
-    push!(molecule, i)
-end
 
 function create_bond_matrix(N::Int)
     # Create a vector to store the SVectors, each containing a pair of integers
@@ -45,12 +26,10 @@ function create_bond_matrix(N::Int)
     end
     return matrix
 end
-
+chains = load_chains("test/molecule.xyz", args=Dict("temperature" => [temperature], "model" => ["Trimer"], "list_type" => "LinkedList", "bonds" => create_bond_matrix(N)))
 
 model_matrix = Trimer()
-bonds = create_bond_matrix(N)
-chains = [System(position, species, molecule, density, temperature, model_matrix, bonds; list_type=LinkedList) for _ in 1:M]
-## Define moves and combine them into a pool
+
 pswap = 0.2
 displacement_policy = SimpleGaussian()
 displacement_parameters = ComponentArray(σ=0.05)

--- a/test/molecules_test.jl
+++ b/test/molecules_test.jl
@@ -26,6 +26,7 @@ function create_bond_matrix(N::Int)
     end
     return matrix
 end
+
 chains = load_chains("test/molecule.xyz", args=Dict("temperature" => [temperature], "model" => ["Trimer"], "list_type" => "LinkedList", "bonds" => create_bond_matrix(N)))
 
 model_matrix = Trimer()
@@ -34,7 +35,7 @@ pswap = 0.2
 displacement_policy = SimpleGaussian()
 displacement_parameters = ComponentArray(σ=0.05)
 pool = (
-    Move(Displacement(0, zero(box), 0.0), displacement_policy, displacement_parameters, 1.0),
+    Move(Displacement(0, zero(chains[1].box), 0.0), displacement_policy, displacement_parameters, 1.0),
 )
 ## Define the simulation struct
 steps = 1000

--- a/test/molecules_test.jl
+++ b/test/molecules_test.jl
@@ -4,7 +4,6 @@ using Distributions
 using Random
 using StaticArrays
 using ComponentArrays
-using PProf, Profile
 
 seed = 42
 rng = Xoshiro(seed)
@@ -28,9 +27,6 @@ function create_bond_matrix(N::Int)
 end
 
 chains = load_chains("test/molecule.xyz", args=Dict("temperature" => [temperature], "model" => ["Trimer"], "list_type" => "LinkedList", "bonds" => create_bond_matrix(N)))
-
-model_matrix = Trimer()
-
 pswap = 0.2
 displacement_policy = SimpleGaussian()
 displacement_parameters = ComponentArray(σ=0.05)


### PR DESCRIPTION
Big PR:

- Change `cell_list ` name to `neighbour_list` as it is more user friendly.
- Merge `destroy_particle!`,` create_particle! `and `compute_local_energy `into `compute_energy_particle`. This is possible thanks to deletion of the energy cache.
- We precalculate the cell neighbours, as we've seen that the calculation at each MC move of neighbours took too much time. We thus see an acceleration of the code.
- Compliance to the new version of code in the test files