### PR TITLE
Chore/compat arianna v0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
-Arianna = "0.1"
+Arianna = "0.2"
 Comonicon = "1.0"
 ComponentArrays = "0.15"
 ConcreteStructs = "0.2"

--- a/examples/movie/params.toml
+++ b/examples/movie/params.toml
@@ -20,7 +20,12 @@ parameters = {sigma = 0.05}
 
 [[simulation.output]]
 algorithm = "StoreCallbacks"
-callbacks = ["energy", "acceptance"]
+callbacks = ["energy"]
+scheduler_params = {linear_interval = 500}
+
+[[simulation.output]]
+algorithm = "StoreAcceptance"
+dependencies = ["Metropolis"]
 scheduler_params = {linear_interval = 500}
 
 [[simulation.output]]

--- a/examples/ortho-terphenyl/2-equilibrate-at-different-temperatures/params-template.toml
+++ b/examples/ortho-terphenyl/2-equilibrate-at-different-temperatures/params-template.toml
@@ -69,7 +69,12 @@ policy = "DoubleUniform"
 
 [[simulation.output]]
 algorithm = "StoreCallbacks"
-callbacks = ["energy", "acceptance"]
+callbacks = ["energy"]
+scheduler_params = {linear_interval = 1000}
+
+[[simulation.output]]
+algorithm = "StoreAcceptance"
+dependencies = ["Metropolis"]
 scheduler_params = {linear_interval = 1000}
 
 [[simulation.output]]

--- a/examples/ortho-terphenyl/3-run-production/params-template.toml
+++ b/examples/ortho-terphenyl/3-run-production/params-template.toml
@@ -69,7 +69,7 @@ policy = "DoubleUniform"
 
 [[simulation.output]]
 algorithm = "StoreCallbacks"
-callbacks = ["energy", "acceptance"]
+callbacks = ["energy"]
 scheduler_params = {linear_interval = 1000}
 
 [[simulation.output]]

--- a/examples/ortho-terphenyl/4-compute-correlation-functions/compute-observables.py
+++ b/examples/ortho-terphenyl/4-compute-correlation-functions/compute-observables.py
@@ -20,7 +20,7 @@ def compute_fskt() -> pd.DataFrame:
     df_list = []
     for T in temperatures:
         print(f"T = {T}")
-        traj = Trajectory(f"../3-run-production/{T}/trajectories/1/trajectory.xyz")
+        traj = Trajectory(f"../3-run-production/{T}/chains/1/trajectory.xyz")
 
         cf = pp.SelfIntermediateScatteringFast(
             traj,

--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -112,7 +112,7 @@ function compute_energy_particle(system::Particles, ids::AbstractVector)
 end
 
 
-export callback_energy
+export energy
 #export nearest_image_distance
 export Model, GeneralKG, JBB, BHHP, SoftSpheres, KobAndersen, Trimer
 export NeighbourList, LinkedList, CellList, EmptyList, VerletList
@@ -249,6 +249,7 @@ ParticlesMC implemented in Comonicon.
     for output in sim["output"]
         alg = output["algorithm"]
         scheduler_params = output["scheduler_params"]
+        dependencies = get(output, "dependencies", nothing)
         callbacks = get(output, "callbacks", [])
         fmt = get(output, "fmt", "XYZ")
         interval = scheduler_params["linear_interval"]
@@ -259,10 +260,17 @@ ParticlesMC implemented in Comonicon.
             sched = build_schedule(steps, burn, interval)
         end
         if alg == "StoreCallbacks"
-            callbacks = map(c -> eval(Meta.parse("callback_$c")), callbacks)
+            callbacks = map(c -> eval(Meta.parse("$c")), callbacks)
             algorithm = (
                 algorithm = eval(Meta.parse(alg)),
                 callbacks = callbacks,
+                scheduler = sched,
+            )
+        elseif alg == "StoreAcceptance"
+            dependencies = map(d -> eval(Meta.parse("$d")), dependencies)
+            algorithm = (
+                algorithm = eval(Meta.parse(alg)),
+                dependencies = dependencies,
                 scheduler = sched,
             )
         elseif alg == "StoreTrajectories" || alg == "StoreLastFrames"

--- a/src/molecules.jl
+++ b/src/molecules.jl
@@ -240,3 +240,7 @@ function compute_chain_correlation(system::Molecules)
     end
     return sum(correlation_array.^2)
 end
+
+Arianna.@callback function chain_correlation(system::Molecules)
+    return compute_chain_correlation(system)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -48,12 +48,12 @@ function SpeciesList(species)
     return SpeciesList(ids, heads)
 end
 
-function callback_energy(simulation)
-    return mean(system.energy[1] / length(system) for system in simulation.chains)
+Arianna.@callback function energy(system)
+    return system.energy[1]
 end
 
-function callback_chain_correlation(simulation)
-    return mean(compute_chain_correlation(system) for system in simulation.chains)
+Arianna.@callback function chain_correlation(system)
+    return compute_chain_correlation(system)
 end
 
 function volume_sphere(r, d::Int)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,7 +49,7 @@ function SpeciesList(species)
 end
 
 Arianna.@callback function energy(system::Particles)
-    return system.energy[1]
+    return system.energy[1] / length(system)
 end
 
 function volume_sphere(r, d::Int)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -48,12 +48,8 @@ function SpeciesList(species)
     return SpeciesList(ids, heads)
 end
 
-Arianna.@callback function energy(system)
+Arianna.@callback function energy(system::Particles)
     return system.energy[1]
-end
-
-Arianna.@callback function chain_correlation(system)
-    return compute_chain_correlation(system)
 end
 
 function volume_sphere(r, d::Int)

--- a/test/gerhard_energy_distribution.jl
+++ b/test/gerhard_energy_distribution.jl
@@ -29,7 +29,6 @@ steps = 1000
 burn = 0
 block = [0, 10]
 sampletimes = build_schedule(steps, burn, block)
-callbacks = (callback_energy, callback_acceptance)
 
 # NO SWAPS
 pswap = 0.0
@@ -41,7 +40,8 @@ pool = (
 
 algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=system.N),
-    (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
+    (algorithm=StoreCallbacks, callbacks=(energy,), scheduler=sampletimes),
+    (algorithm=StoreAcceptance, dependencies=(Metropolis,), scheduler=sampletimes),
     (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=EXYZ()),
     (algorithm=StoreLastFrames, scheduler=[steps], fmt=EXYZ()),
     (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10)),
@@ -72,7 +72,8 @@ pool = (
 )
 algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=system.N),
-    (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
+    (algorithm=StoreCallbacks, callbacks=(energy,), scheduler=sampletimes),
+    (algorithm=StoreAcceptance, dependencies=(Metropolis,), scheduler=sampletimes),
     (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=LAMMPS()),
     (algorithm=StoreLastFrames, scheduler=[steps], fmt=EXYZ()),
     (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10)),
@@ -105,7 +106,8 @@ pool = (
 )
 algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=system.N),
-    (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
+    (algorithm=StoreCallbacks, callbacks=(energy,), scheduler=sampletimes),
+    (algorithm=StoreAcceptance, dependencies=(Metropolis,), scheduler=sampletimes),
     (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=LAMMPS()),
     (algorithm=StoreLastFrames, scheduler=[steps], fmt=LAMMPS()),
     (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10)),

--- a/test/molecules_test.jl
+++ b/test/molecules_test.jl
@@ -43,8 +43,8 @@ callbacks = (callback_energy, callback_acceptance)
 path = "data/test/particles/Molecules/T$temperature/N$N/M$M/seed$seed"
 algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=N),
-    (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
-    (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=XYZ()),
+    (algorithm=StoreCallbacks, callbacks=(energy,), scheduler=sampletimes),
+    (algorithm=StoreAcceptance, dependencies=(Metropolis,), scheduler=sampletimes),    (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=XYZ()),
     (algorithm=StoreLastFrames, scheduler=[steps], fmt=XYZ()),
     (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10), fmt=XYZ())
     )

--- a/test/params.toml
+++ b/test/params.toml
@@ -20,8 +20,13 @@ parameters = {sigma = 0.05}
 
 [[simulation.output]]
 algorithm = "StoreCallbacks"
-callbacks = ["energy", "acceptance"]
+callbacks = ["energy"]
 scheduler_params = {linear_interval = 100}
+
+[[simulation.output]]
+algorithm = "StoreAcceptance"
+dependencies = ["Metropolis"]
+scheduler_params = {linear_interval = 500}
 
 [[simulation.output]]
 algorithm = "StoreTrajectories"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,6 @@ end
     burn = 0
     block = [0, 1, 2, 4, 8]
     sampletimes = build_schedule(steps, burn, block)
-    callbacks = (callback_energy, callback_acceptance)
 
     # NO SWAPS
     pswap = 0.0
@@ -57,7 +56,8 @@ end
     )
     algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=system_el.N),
-    (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
+    (algorithm=StoreCallbacks, callbacks=(energy,), scheduler=sampletimes),
+    (algorithm=StoreAcceptance, dependencies=(Metropolis,), scheduler=sampletimes), 
     (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=EXYZ()),
     (algorithm=StoreLastFrames, scheduler=[steps], fmt=LAMMPS()),
     (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10)),
@@ -81,9 +81,9 @@ end
     run!(simulation)
 
     ## Read energy data and compare
-    path_energy_el = joinpath(path_el, "energy.dat")
-    path_energy_ll = joinpath(path_ll, "energy.dat")
-    path_energy_vl = joinpath(path_vl, "energy.dat")
+    path_energy_el = joinpath(path_el, "chains/1/energy.dat")
+    path_energy_ll = joinpath(path_ll, "chains/1/energy.dat")
+    path_energy_vl = joinpath(path_vl, "chains/1/energy.dat")
     energy_el= readdlm(path_energy_el)[:, 2]
     energy_ll = readdlm(path_energy_ll)[:, 2]
     energy_vl = readdlm(path_energy_vl)[:, 2]
@@ -103,7 +103,8 @@ end
     )
     algorithm_list = (
         (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=system_el.N),
-        (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes, fmt=XYZ()),
+        (algorithm=StoreCallbacks, callbacks=(energy,), scheduler=sampletimes),
+        (algorithm=StoreAcceptance, dependencies=(Metropolis,), scheduler=sampletimes),
         (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=XYZ()),
         (algorithm=StoreLastFrames, scheduler=[steps], fmt=XYZ()),
         (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10), fmt=XYZ()),
@@ -121,8 +122,8 @@ end
     run!(simulation)
 
     ## Read energy data and compare
-    path_energy_el = joinpath(path_el, "energy.dat")
-    path_energy_ll = joinpath(path_ll, "energy.dat")
+    path_energy_el = joinpath(path_el, "chains/1/energy.dat")
+    path_energy_ll = joinpath(path_ll, "chains/1/energy.dat")
     energy_el= readdlm(path_energy_el)[:, 2]
     energy_ll = readdlm(path_energy_ll)[:, 2]
     @test isapprox(energy_el, energy_ll, atol=1e-6)
@@ -154,7 +155,6 @@ end
     burn = 0
     block = [0, 1, 2, 4, 8]
     sampletimes = build_schedule(steps, burn, block)
-    callbacks = (callback_energy, callback_acceptance)
 
     # NO SWAPS
     pswap = 0.0
@@ -165,7 +165,8 @@ end
     )
     algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=system_el.N),
-    (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
+    (algorithm=StoreCallbacks, callbacks=(energy,), scheduler=sampletimes),
+    (algorithm=StoreAcceptance, dependencies=(Metropolis,), scheduler=sampletimes),        
     (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=EXYZ()),
     (algorithm=StoreLastFrames, scheduler=[steps], fmt=EXYZ()),
     (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10)),
@@ -183,8 +184,8 @@ end
     run!(simulation)
 
     ## Read energy data and compare
-    path_energy_el = joinpath(path_el, "energy.dat")
-    path_energy_ll = joinpath(path_ll, "energy.dat")
+    path_energy_el = joinpath(path_el, "chains/1/energy.dat")
+    path_energy_ll = joinpath(path_ll, "chains/1/energy.dat")
     energy_el= readdlm(path_energy_el)[:, 2]
     energy_ll = readdlm(path_energy_ll)[:, 2]
     @test isapprox(energy_el, energy_ll, atol=1e-6)

--- a/test/simple_test.jl
+++ b/test/simple_test.jl
@@ -49,8 +49,8 @@ callbacks = (callback_energy, callback_acceptance)
 
 algorithm_list = (
     (algorithm=Metropolis, pool=pool, seed=seed, parallel=false, sweepstep=length(system_ll)),
-    (algorithm=StoreCallbacks, callbacks=(callback_energy, callback_acceptance), scheduler=sampletimes),
-    (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=XYZ()),
+    (algorithm=StoreCallbacks, callbacks=(energy,), scheduler=sampletimes),
+    (algorithm=StoreAcceptance, dependencies=(Metropolis,), scheduler=sampletimes),    (algorithm=StoreTrajectories, scheduler=sampletimes, fmt=XYZ()),
     (algorithm=StoreLastFrames, scheduler=[steps], fmt=XYZ()),
     (algorithm=PrintTimeSteps, scheduler=build_schedule(steps, burn, steps ÷ 10)),
 )


### PR DESCRIPTION
Files are changed to comply with the new `Arianna` version.
Now, each `chain` has its own numbered folder, where individual callbacks+ trajectories are stored.
The acceptance is not a callback anymore and the `StoreAcceptance` algorithm is now used. The `StoreAcceptance` algorithm is now parsed, when running commands from CLI. 
Callbacks have changed names and are not named `function callback_*`.
Callback functions are not written as:
```julia
Arianna.@callback function my_callback()
```





