### PR TITLE
fix run.sh: explicit density list and fix output path

### DIFF
--- a/examples/ortho-terphenyl/1-create-config-right-density/run.sh
+++ b/examples/ortho-terphenyl/1-create-config-right-density/run.sh
@@ -2,15 +2,15 @@
 
 uv run --script create-initial-config.py
 
-density=0.2
+densities=(0.2 0.22 0.24 0.27 0.30 0.33 0.36 0.40 0.44 0.48 0.53 0.58 0.64 0.70 0.77 0.85 0.93 1.02 1.12 1.2)
 
-while (( $(echo "$density < 1.2" | bc -l ) ))
+for density in "${densities[@]}"
 do
     echo "Density" $density
-
     sed "s/DENSITY/$density/" params-template.toml > params.toml
     particlesmc params.toml
-    cp trajectories/1/lastframe.xyz inputframe.xyz
-
-    density=$(echo "$density" | awk '{printf "%f", $1 * 1.1}')
+    cp chains/1/lastframe.xyz inputframe.xyz
+    echo "Done density: $density"
 done
+
+echo "Final density: $density"


### PR DESCRIPTION
Two issues in the original run.sh:
1. Formatting issue that broke the while loop and prevented reaching density 1.2 exactly → replaced with an explicit density lis. 
2. Wrong output path: trajectories/ → chains/