### PR TITLE
fixed the chains usage in ParticlesMC

### DIFF
--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -177,7 +177,8 @@ ParticlesMC implemented in Comonicon.
             "list_type" => list_type,
             "list_parameters" => list_parameters,
             "bonds" => bonds,
-        ),filename=filename
+        ),
+        filename=filename,
         )
     else
         chains = load_chains(config, args=Dict(
@@ -186,7 +187,8 @@ ParticlesMC implemented in Comonicon.
             "model" => model,
             "list_type" => list_type,
             "list_parameters" => list_parameters,
-        ),filename=filename
+        ),
+        filename=filename,
         )
     end
     algorithm_list = []

--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -149,9 +149,10 @@ ParticlesMC implemented in Comonicon.
     if model === nothing
         model = params["model"]
     end  # optional field
-    if !isfile(config)
+    if !isfile(config) && !isdir(config)
         error("Configuration file '$config' does not exist in the current path.")
     end
+    filename = isdir(config) ? filename = system["filename"] : "" # if the config is a directory then one need to specify the root of the filenames in toml (include that in README?)
     list_type = get(system, "list_type", "LinkedList")  # optional field
     list_parameters = get(system, "list_parameters", nothing)  # optional field
     bonds = get(system, "bonds", nothing)
@@ -176,7 +177,8 @@ ParticlesMC implemented in Comonicon.
             "list_type" => list_type,
             "list_parameters" => list_parameters,
             "bonds" => bonds,
-        ))
+        ),filename=filename
+        )
     else
         chains = load_chains(config, args=Dict(
             "temperature" => temperature,
@@ -184,7 +186,8 @@ ParticlesMC implemented in Comonicon.
             "model" => model,
             "list_type" => list_type,
             "list_parameters" => list_parameters,
-        ))
+        ),filename=filename
+        )
     end
     algorithm_list = []
     # Setup moves


### PR DESCRIPTION
The chains load was broken. This fix allows using a configuration directory to handle multiple initial conditions. 

This requires adding a `filename = "init"` entry to the TOML file if a directory is used. 
(Maybe adding a section to describe the usage of multiple chains in the README could be a good idea later on).

I have verified that it still supports a single configuration file as input.