### PR TITLE
New scheduler building logic ; Arianna.jl dependency to v0.2.1

### DIFF
--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -118,10 +118,9 @@ end
 
 function parse_schedule(scheduler_params, steps, burn)
     if haskey(scheduler_params, "multi_origins")
-        tmax = scheduler_params["multi_origins"]["tmax"]
         tw   = scheduler_params["multi_origins"]["tw"]
         N    = scheduler_params["multi_origins"]["N"]
-        return build_schedule(tmax, MultiOrigins(tw, N), burn=burn)
+        return build_schedule(steps, MultiOrigins(tw, N), burn=burn)
     elseif haskey(scheduler_params, "log_base")
         interval = get(scheduler_params, "linear_interval", 1)
         block    = build_schedule(interval, 0, 2.0)

--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -112,6 +112,25 @@ function compute_energy_particle(system::Particles, ids::AbstractVector)
     return map(i -> compute_energy_particle(system, i), ids)
 end
 
+"""
+    Helper for building scheduler based on TOML schedul parameters
+"""
+
+function build_sched(scheduler_params, steps, burn)
+    if haskey(scheduler_params, "tmax") && haskey(scheduler_params, "tw") && haskey(scheduler_params, "N")
+        tmax = scheduler_params["tmax"]
+        tw   = scheduler_params["tw"]
+        N    = scheduler_params["N"]
+        return build_schedule(tmax, MultiOrigins(tw, N), burn=burn)
+    elseif haskey(scheduler_params, "log_base")
+        interval = get(scheduler_params, "linear_interval", 1)
+        block    = build_schedule(interval, 0, 2.0)
+        return build_schedule(steps, burn, block)
+    else
+        interval = get(scheduler_params, "linear_interval", 1)
+        return build_schedule(steps, burn, interval)
+    end
+end
 
 export energy
 #export nearest_image_distance
@@ -256,13 +275,7 @@ ParticlesMC implemented in Comonicon.
     for observable in get(sim, "observable", [])
         alg = observable["algorithm"]
         scheduler_params = observable["scheduler_params"]
-        interval = get(scheduler_params, "linear_interval", 1)
-        if "log_base" in keys(scheduler_params)
-            block = build_schedule(interval, 0, 2.0)
-            sched = build_schedule(steps, burn, block)
-        else
-            sched = build_schedule(steps, burn, interval)
-        end
+        sched = build_sched(scheduler_params, steps, burn)
         if alg == "ComputeRotation"
             parameters = get(observable, "parameters", Dict())
             theta_T    = Float64.(get(parameters, "theta_T", [π/4]))
@@ -284,13 +297,7 @@ ParticlesMC implemented in Comonicon.
         dependencies = get(output, "dependencies", nothing)
         callbacks = get(output, "callbacks", [])
         fmt = get(output, "fmt", "XYZ")
-        interval = scheduler_params["linear_interval"]
-        if "log_base" in keys(scheduler_params)
-            block = build_schedule(interval, 0, 2.0)
-            sched = build_schedule(steps, burn, block)
-        else
-            sched = build_schedule(steps, burn, interval)
-        end
+        sched = build_sched(scheduler_params, steps, burn)
         if alg == "StoreCallbacks"
             callbacks = map(c -> eval(Meta.parse("$c")), callbacks)
             algorithm = (

--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -274,7 +274,7 @@ ParticlesMC implemented in Comonicon.
     for observable in get(sim, "observable", [])
         alg = observable["algorithm"]
         scheduler_params = observable["scheduler_params"]
-        sched = build_sched(scheduler_params, steps, burn)
+        sched = parse_schedule(scheduler_params, steps, burn)
         if alg == "ComputeRotation"
             parameters = get(observable, "parameters", Dict())
             theta_T    = Float64.(get(parameters, "theta_T", [π/4]))
@@ -296,7 +296,7 @@ ParticlesMC implemented in Comonicon.
         dependencies = get(output, "dependencies", nothing)
         callbacks = get(output, "callbacks", [])
         fmt = get(output, "fmt", "XYZ")
-        sched = build_sched(scheduler_params, steps, burn)
+        sched = parse_schedule(scheduler_params, steps, burn)
         if alg == "StoreCallbacks"
             callbacks = map(c -> eval(Meta.parse("$c")), callbacks)
             algorithm = (

--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -117,10 +117,10 @@ end
 """
 
 function build_sched(scheduler_params, steps, burn)
-    if haskey(scheduler_params, "tmax") && haskey(scheduler_params, "tw") && haskey(scheduler_params, "N")
-        tmax = scheduler_params["tmax"]
-        tw   = scheduler_params["tw"]
-        N    = scheduler_params["N"]
+    if haskey(scheduler_params, "multi_origins")
+        tmax = scheduler_params["multi_origins"]["tmax"]
+        tw   = scheduler_params["multi_origins"]["tw"]
+        N    = scheduler_params["multi_origins"]["N"]
         return build_schedule(tmax, MultiOrigins(tw, N), burn=burn)
     elseif haskey(scheduler_params, "log_base")
         interval = get(scheduler_params, "linear_interval", 1)

--- a/src/ParticlesMC.jl
+++ b/src/ParticlesMC.jl
@@ -116,7 +116,7 @@ end
     Helper for building scheduler based on TOML schedul parameters
 """
 
-function build_sched(scheduler_params, steps, burn)
+function parse_schedule(scheduler_params, steps, burn)
     if haskey(scheduler_params, "multi_origins")
         tmax = scheduler_params["multi_origins"]["tmax"]
         tw   = scheduler_params["multi_origins"]["tw"]

--- a/src/molecules.jl
+++ b/src/molecules.jl
@@ -78,7 +78,11 @@ Returns
 function System(position, species, molecule, density::T, temperature::T, model_matrix, bonds; molecule_species=nothing, list_type=EmptyList, list_parameters=nothing) where {T<:AbstractFloat}
     @assert length(position) == length(species)
     N = length(position)
+<<<<<<< HEAD
     Φ = Vector{Vector{SVector{3,T}}}()   # empty, filled by ComputeRotation
+=======
+    phi = Vector{Vector{SVector{3,T}}}()   # empty, filled by ComputeRotation
+>>>>>>> a55744b (add phi field in the Molecules struct to be callable)
     Nmol = length(unique(molecule))
     start_mol, length_mol = get_first_and_counts(molecule)
     molecule_species = something(molecule_species, ones(Int, N))
@@ -87,7 +91,11 @@ function System(position, species, molecule, density::T, temperature::T, model_m
     energy = zeros(T, 1)
     maxcut = maximum([model.rcut for model in model_matrix])
     neighbour_list = list_type(box, maxcut, N; list_parameters=list_parameters)
+<<<<<<< HEAD
     system = Molecules(position, Φ, species, molecule, molecule_species,  start_mol, length_mol, density, temperature, energy, model_matrix, d, N, Nmol,box, neighbour_list, bonds)
+=======
+    system = Molecules(position, phi, species, molecule, molecule_species,  start_mol, length_mol, density, temperature, energy, model_matrix, d, N, Nmol,box, neighbour_list, bonds)
+>>>>>>> a55744b (add phi field in the Molecules struct to be callable)
     build_neighbour_list!(system)
     local_energy = [compute_energy_particle(system, i, neighbour_list) for i in eachindex(position)]
     energy = sum(local_energy) / 2

--- a/src/molecules.jl
+++ b/src/molecules.jl
@@ -78,11 +78,7 @@ Returns
 function System(position, species, molecule, density::T, temperature::T, model_matrix, bonds; molecule_species=nothing, list_type=EmptyList, list_parameters=nothing) where {T<:AbstractFloat}
     @assert length(position) == length(species)
     N = length(position)
-<<<<<<< HEAD
     Φ = Vector{Vector{SVector{3,T}}}()   # empty, filled by ComputeRotation
-=======
-    phi = Vector{Vector{SVector{3,T}}}()   # empty, filled by ComputeRotation
->>>>>>> a55744b (add phi field in the Molecules struct to be callable)
     Nmol = length(unique(molecule))
     start_mol, length_mol = get_first_and_counts(molecule)
     molecule_species = something(molecule_species, ones(Int, N))
@@ -91,11 +87,7 @@ function System(position, species, molecule, density::T, temperature::T, model_m
     energy = zeros(T, 1)
     maxcut = maximum([model.rcut for model in model_matrix])
     neighbour_list = list_type(box, maxcut, N; list_parameters=list_parameters)
-<<<<<<< HEAD
     system = Molecules(position, Φ, species, molecule, molecule_species,  start_mol, length_mol, density, temperature, energy, model_matrix, d, N, Nmol,box, neighbour_list, bonds)
-=======
-    system = Molecules(position, phi, species, molecule, molecule_species,  start_mol, length_mol, density, temperature, energy, model_matrix, d, N, Nmol,box, neighbour_list, bonds)
->>>>>>> a55744b (add phi field in the Molecules struct to be callable)
     build_neighbour_list!(system)
     local_energy = [compute_energy_particle(system, i, neighbour_list) for i in eachindex(position)]
     energy = sum(local_energy) / 2

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -3,7 +3,7 @@
 # Compute on-the-fly rotation tracker.
 # Two algorithms :
 # 1. ComputeRotation : updates system.Φ (simulation.observable)
-# 2. StoreΦTrajectory : writes system.Φ to disk
+# 2. StorePhiTrajectory : writes system.Φ to disk
 # system.Φ[k][m] = rotation vector for molecule m under theta_T[k]
 
 using LinearAlgebra

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -151,7 +151,12 @@ function Arianna.finalise(::ComputeRotation, ::Simulation) end
 ##### Store rotation vector trajectory #####
 ##########                        ##########
 
+<<<<<<< HEAD
 function write_phi_frame(file::IOStream, t::Int, N_mol::Int, Φs::Vector{<:SVector})
+=======
+function write_phi_frame(file::IOStream, t::Int, N_mol::Int,
+                         Φs::Vector{<:SVector})
+>>>>>>> 1261e92 (changed variables 'phi' to 'Φ')
     println(file, N_mol)
     println(file, "t=$t")
     for m in 1:N_mol
@@ -186,7 +191,11 @@ function Arianna.initialise(algorithm::StorePhiTrajectories, simulation::Simulat
     for c in eachindex(simulation.chains)
         system = simulation.chains[c]
         n_θ    = length(system.Φ)
+<<<<<<< HEAD
         algorithm.paths[c] = [joinpath(algorithm.dirs[c], "phitrajectories_$k.dat")
+=======
+        algorithm.paths[c] = [joinpath(algorithm.dirs[c], "Φtrajectories_$k.dat")
+>>>>>>> 1261e92 (changed variables 'phi' to 'Φ')
                                for k in 1:n_θ]
         algorithm.files[c] = open.(algorithm.paths[c], "w")
     end

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -114,9 +114,15 @@ function Arianna.initialise(algorithm::ComputeRotation, simulation::Simulation)
         state.Φ_acc      = [[zero(SVector{3,T}) for _ in 1:N_mol] for _ in 1:n_θ]
         state.initialized  = true
         
+<<<<<<< HEAD
         resize!(system.Φ, n_θ) # a posteriori as we know n_θ
         for k in 1:n_θ
             system.Φ[k] = [zero(SVector{3,T}) for _ in 1:N_mol]
+=======
+        resize!(system.phi, n_θ) # a posteriori as we know n_θ
+        for k in 1:n_θ
+            system.phi[k] = [zero(SVector{3,T}) for _ in 1:N_mol]
+>>>>>>> 366591a (initialise system.phi)
         end
     end
 end

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -114,15 +114,9 @@ function Arianna.initialise(algorithm::ComputeRotation, simulation::Simulation)
         state.Φ_acc      = [[zero(SVector{3,T}) for _ in 1:N_mol] for _ in 1:n_θ]
         state.initialized  = true
         
-<<<<<<< HEAD
         resize!(system.Φ, n_θ) # a posteriori as we know n_θ
         for k in 1:n_θ
             system.Φ[k] = [zero(SVector{3,T}) for _ in 1:N_mol]
-=======
-        resize!(system.phi, n_θ) # a posteriori as we know n_θ
-        for k in 1:n_θ
-            system.phi[k] = [zero(SVector{3,T}) for _ in 1:N_mol]
->>>>>>> 366591a (initialise system.phi)
         end
     end
 end
@@ -157,12 +151,7 @@ function Arianna.finalise(::ComputeRotation, ::Simulation) end
 ##### Store rotation vector trajectory #####
 ##########                        ##########
 
-<<<<<<< HEAD
 function write_phi_frame(file::IOStream, t::Int, N_mol::Int, Φs::Vector{<:SVector})
-=======
-function write_phi_frame(file::IOStream, t::Int, N_mol::Int,
-                         Φs::Vector{<:SVector})
->>>>>>> 1261e92 (changed variables 'phi' to 'Φ')
     println(file, N_mol)
     println(file, "t=$t")
     for m in 1:N_mol
@@ -197,11 +186,7 @@ function Arianna.initialise(algorithm::StorePhiTrajectories, simulation::Simulat
     for c in eachindex(simulation.chains)
         system = simulation.chains[c]
         n_θ    = length(system.Φ)
-<<<<<<< HEAD
         algorithm.paths[c] = [joinpath(algorithm.dirs[c], "phitrajectories_$k.dat")
-=======
-        algorithm.paths[c] = [joinpath(algorithm.dirs[c], "Φtrajectories_$k.dat")
->>>>>>> 1261e92 (changed variables 'phi' to 'Φ')
                                for k in 1:n_θ]
         algorithm.files[c] = open.(algorithm.paths[c], "w")
     end

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -126,7 +126,7 @@ end
 
 function Arianna.make_step!(simulation::Simulation, algorithm::ComputeRotation)
 
-    collect(eachindex(simulation.chains) |> Transducers.Map(c -> begin
+    tcollect(eachindex(simulation.chains) |> Transducers.Map(c -> begin
         system = simulation.chains[c]
         state  = algorithm.states[c]
         N_mol  = system.Nmol


### PR DESCRIPTION
This PR is using `Arianna.jl` new dependency which introduces a new way to schedule outputs in simulation. 

Created the `build_sched(scheduler_params, steps, burn)` helper function to eliminate duplicated [if/else](url) structures block for observables and outputs.
The new scheduler is called in TOML by the keyword : `multi_origins`. 
e.g : `scheduler_params = {multi_origins = {tmax = x , tw = y , N = z}}` 

